### PR TITLE
feat: tab menu component 🗂️🧩

### DIFF
--- a/components/InsetShadow/InsetShadow.stories.tsx
+++ b/components/InsetShadow/InsetShadow.stories.tsx
@@ -7,7 +7,7 @@ const InsetShadowMeta: Meta<typeof InsetShadow> = {
   title: 'InsetShadow',
   args: {
     borderRadius: 16,
-    className: 'justify-center items-center'
+    className: 'justify-center items-center h-full'
   },
   component: (props) => (
     <View className='h-24 w-full items-center rounded-2xl bg-primary-700'>

--- a/components/InsetShadow/InsetShadow.stories.tsx
+++ b/components/InsetShadow/InsetShadow.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import InsetShadow from './InsetShadow'
+import { View } from 'react-native'
+import Text from '../Text'
+
+const InsetShadowMeta: Meta<typeof InsetShadow> = {
+  title: 'InsetShadow',
+  args: {
+    borderRadius: 16,
+    className: 'justify-center items-center'
+  },
+  component: (props) => (
+    <View className='h-24 w-full items-center rounded-2xl bg-primary-700'>
+      <InsetShadow {...props}>
+        <Text>Some text</Text>
+      </InsetShadow>
+    </View>
+  )
+}
+
+export default InsetShadowMeta
+
+type Story = StoryObj<typeof InsetShadow>
+
+export const Default: Story = {}

--- a/components/InsetShadow/InsetShadow.tsx
+++ b/components/InsetShadow/InsetShadow.tsx
@@ -44,9 +44,9 @@ const InsetShadow = ({
           >
             <BoxShadow
               dx={0}
-              dy={0}
-              blur={4}
-              color='#262626'
+              dy={1}
+              blur={3}
+              color='#222'
               inner
             />
           </Box>

--- a/components/InsetShadow/InsetShadow.tsx
+++ b/components/InsetShadow/InsetShadow.tsx
@@ -38,8 +38,8 @@ const InsetShadow = ({
           color='transparent'
         >
           <BoxShadow
-            dx={-1}
-            dy={-1}
+            dx={0}
+            dy={0}
             blur={8}
             color='#262626'
             inner

--- a/components/InsetShadow/InsetShadow.tsx
+++ b/components/InsetShadow/InsetShadow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type PropsWithChildren } from 'react'
+import { memo, useCallback, useState, type PropsWithChildren } from 'react'
 import { type LayoutChangeEvent, StyleSheet, View } from 'react-native'
 import { Canvas, Box, BoxShadow, rect, rrect } from '@shopify/react-native-skia'
 import clsx from 'clsx'
@@ -27,25 +27,31 @@ const InsetShadow = ({
     },
     []
   )
+
   return (
     <View
-      className={clsx('h-full w-full', className)}
+      className={clsx('w-full', className)}
       onLayout={onLayout}
     >
-      <Canvas style={[styles.canvas, { width, height }]}>
-        <Box
-          box={rrect(rect(0, 0, width, height), borderRadius, borderRadius)}
-          color='transparent'
-        >
-          <BoxShadow
-            dx={0}
-            dy={0}
-            blur={8}
-            color='#262626'
-            inner
-          />
-        </Box>
-      </Canvas>
+      <View
+        pointerEvents='none'
+        style={styles.canvas}
+      >
+        <Canvas style={{ width, height }}>
+          <Box
+            box={rrect(rect(0, 0, width, height), borderRadius, borderRadius)}
+            color='transparent'
+          >
+            <BoxShadow
+              dx={0}
+              dy={0}
+              blur={4}
+              color='#262626'
+              inner
+            />
+          </Box>
+        </Canvas>
+      </View>
       {children}
     </View>
   )
@@ -56,8 +62,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     top: 0,
-    pointerEvents: 'none'
+    zIndex: 10
   }
 })
 
-export default InsetShadow
+export default memo(InsetShadow)

--- a/components/InsetShadow/InsetShadow.tsx
+++ b/components/InsetShadow/InsetShadow.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useState, type PropsWithChildren } from 'react'
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native'
+import { Canvas, Box, BoxShadow, rect, rrect } from '@shopify/react-native-skia'
+import clsx from 'clsx'
+
+type InsetShadowProps = PropsWithChildren<{
+  className?: string
+  borderRadius: number
+}>
+
+const InsetShadow = ({
+  children,
+  className,
+  borderRadius
+}: InsetShadowProps) => {
+  const [{ width, height }, setWrapperDimensions] = useState({
+    width: 0,
+    height: 0
+  })
+  const onLayout = useCallback(
+    ({
+      nativeEvent: {
+        layout: { width, height }
+      }
+    }: LayoutChangeEvent) => {
+      setWrapperDimensions({ width, height })
+    },
+    []
+  )
+  return (
+    <View
+      className={clsx('h-full w-full', className)}
+      onLayout={onLayout}
+    >
+      <Canvas style={[styles.canvas, { width, height }]}>
+        <Box
+          box={rrect(rect(0, 0, width, height), borderRadius, borderRadius)}
+          color='transparent'
+        >
+          <BoxShadow
+            dx={-1}
+            dy={-1}
+            blur={8}
+            color='#262626'
+            inner
+          />
+        </Box>
+      </Canvas>
+      {children}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    pointerEvents: 'none'
+  }
+})
+
+export default InsetShadow

--- a/components/InsetShadow/index.ts
+++ b/components/InsetShadow/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InsetShadow'

--- a/components/TabMenu/TabMenu.stories.tsx
+++ b/components/TabMenu/TabMenu.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import TabMenu from './TabMenu'
+
+const TabMenuMeta: Meta<typeof TabMenu> = {
+  title: 'TabMenu',
+  component: TabMenu,
+  args: {
+    onOptionSelected: () => {},
+    options: ['enhancements', 'units', 'other']
+  }
+}
+
+export default TabMenuMeta
+
+type Story = StoryObj<typeof TabMenuMeta>
+
+export const Default: Story = {}

--- a/components/TabMenu/TabMenu.tsx
+++ b/components/TabMenu/TabMenu.tsx
@@ -7,6 +7,7 @@ import Animated, {
   withSpring
 } from 'react-native-reanimated'
 import InnerBorder from '../InnerBorder'
+import InsetShadow from '../InsetShadow'
 
 type TabMenuProps = {
   options: string[]
@@ -60,30 +61,35 @@ const TabMenu = ({ options, onOptionSelected }: TabMenuProps) => {
   const selectorStyle = useMemo(() => [style, rStyle], [rStyle, style])
 
   return (
-    <View
-      className='w-full flex-row items-center rounded-3xl bg-primary-800 p-2'
-      onLayout={onLayout}
+    <InsetShadow
+      borderRadius={24}
+      className='rounded-3xl'
     >
-      {options.map((opt, idx) => (
-        <TabMenuItem
-          key={opt}
-          onPress={() => {
-            setSelectedIndex(idx)
-          }}
-          option={opt}
-          isSelected={selectedIndex === idx}
-        />
-      ))}
-      <Animated.View
-        pointerEvents='none'
-        className='absolute -z-10 h-full rounded-2xl bg-primary-950 shadow'
-        style={selectorStyle}
+      <View
+        className='w-full flex-row items-center rounded-3xl bg-primary-800 p-2'
+        onLayout={onLayout}
       >
-        <InnerBorder rounded='rounded-2xl'>
-          <View className='h-full w-full' />
-        </InnerBorder>
-      </Animated.View>
-    </View>
+        {options.map((opt, idx) => (
+          <TabMenuItem
+            key={opt}
+            onPress={() => {
+              setSelectedIndex(idx)
+            }}
+            option={opt}
+            isSelected={selectedIndex === idx}
+          />
+        ))}
+        <Animated.View
+          pointerEvents='none'
+          className='absolute -z-10 h-full rounded-2xl bg-primary-950 shadow'
+          style={selectorStyle}
+        >
+          <InnerBorder rounded='rounded-2xl'>
+            <View className='h-full w-full' />
+          </InnerBorder>
+        </Animated.View>
+      </View>
+    </InsetShadow>
   )
 }
 

--- a/components/TabMenu/TabMenu.tsx
+++ b/components/TabMenu/TabMenu.tsx
@@ -1,0 +1,83 @@
+import { type LayoutChangeEvent, StyleSheet, View } from 'react-native'
+import TabMenuItem from './TabMenuItem'
+import { useCallback, useEffect, useState } from 'react'
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring
+} from 'react-native-reanimated'
+import InnerBorder from '../InnerBorder'
+
+type TabMenuProps = {
+  options: string[]
+  onOptionSelected: (opt: string) => void
+}
+
+const TabMenu = ({ options, onOptionSelected }: TabMenuProps) => {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [wrapperWidth, setWrapperWidth] = useState(0)
+  const translationX = useSharedValue(0)
+  useEffect(() => {
+    const selectedOption = options.at(selectedIndex)
+    if (!selectedOption) {
+      return
+    }
+    translationX.value =
+      8 + ((wrapperWidth - 16) / options.length) * selectedIndex
+    onOptionSelected(selectedOption)
+  }, [onOptionSelected, options, selectedIndex, translationX, wrapperWidth])
+
+  const onLayout = useCallback(
+    ({
+      nativeEvent: {
+        layout: { width }
+      }
+    }: LayoutChangeEvent) => {
+      setWrapperWidth(width)
+    },
+    []
+  )
+
+  const style = {
+    width: (wrapperWidth - 16) / options.length
+  }
+  const rStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateX: withSpring(translationX.value, {
+          stiffness: 130,
+          damping: 19
+        })
+      }
+    ]
+  }))
+
+  return (
+    <View
+      className='w-full flex-row items-center rounded-3xl bg-primary-800 p-2'
+      onLayout={onLayout}
+    >
+      {options.map((opt, idx) => (
+        <TabMenuItem
+          key={opt}
+          onPress={() => {
+            setSelectedIndex(idx)
+          }}
+          option={opt}
+          isSelected={selectedIndex === idx}
+        />
+      ))}
+      <Animated.View
+        pointerEvents='none'
+        className='absolute -z-10 h-full rounded-2xl bg-primary-950'
+        style={[style, rStyle]}
+      >
+        <InnerBorder rounded='rounded-2xl'>
+          <View className='h-full w-full' />
+        </InnerBorder>
+      </Animated.View>
+    </View>
+  )
+}
+
+export default TabMenu

--- a/components/TabMenu/TabMenu.tsx
+++ b/components/TabMenu/TabMenu.tsx
@@ -1,6 +1,6 @@
-import { type LayoutChangeEvent, StyleSheet, View } from 'react-native'
+import { type LayoutChangeEvent, View } from 'react-native'
 import TabMenuItem from './TabMenuItem'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -17,6 +17,7 @@ const TabMenu = ({ options, onOptionSelected }: TabMenuProps) => {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [wrapperWidth, setWrapperWidth] = useState(0)
   const translationX = useSharedValue(0)
+
   useEffect(() => {
     const selectedOption = options.at(selectedIndex)
     if (!selectedOption) {
@@ -38,9 +39,13 @@ const TabMenu = ({ options, onOptionSelected }: TabMenuProps) => {
     []
   )
 
-  const style = {
-    width: (wrapperWidth - 16) / options.length
-  }
+  const style = useMemo(
+    () => ({
+      width: (wrapperWidth - 16) / options.length
+    }),
+    [options.length, wrapperWidth]
+  )
+
   const rStyle = useAnimatedStyle(() => ({
     transform: [
       {
@@ -51,6 +56,8 @@ const TabMenu = ({ options, onOptionSelected }: TabMenuProps) => {
       }
     ]
   }))
+
+  const selectorStyle = useMemo(() => [style, rStyle], [rStyle, style])
 
   return (
     <View
@@ -69,8 +76,8 @@ const TabMenu = ({ options, onOptionSelected }: TabMenuProps) => {
       ))}
       <Animated.View
         pointerEvents='none'
-        className='absolute -z-10 h-full rounded-2xl bg-primary-950'
-        style={[style, rStyle]}
+        className='absolute -z-10 h-full rounded-2xl bg-primary-950 shadow'
+        style={selectorStyle}
       >
         <InnerBorder rounded='rounded-2xl'>
           <View className='h-full w-full' />

--- a/components/TabMenu/TabMenuItem.tsx
+++ b/components/TabMenu/TabMenuItem.tsx
@@ -39,13 +39,14 @@ const TabMenuItem = ({ isSelected, option, onPress }: TabMenuItemProps) => {
 
   return (
     <Pressable
-      className='flex-1 items-center justify-center rounded-2xl px-4 py-2 shadow-soft-1'
+      className='flex-1 items-center justify-center rounded-2xl px-4 py-2'
       onPress={() => {
         onPress(option)
       }}
     >
       <AnimatedText
-        className='text-sm uppercase'
+        className='text-ellipsis text-sm uppercase'
+        numberOfLines={1}
         family='body-bold'
         style={rStyle}
       >

--- a/components/TabMenu/TabMenuItem.tsx
+++ b/components/TabMenu/TabMenuItem.tsx
@@ -1,0 +1,58 @@
+import { Pressable } from 'react-native'
+import Text from '../Text'
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming
+} from 'react-native-reanimated'
+import { useSelector } from 'react-redux'
+import { selectThemeName } from '../store'
+import { themeColors } from '../ui'
+import { useEffect } from 'react'
+
+type TabMenuItemProps = {
+  option: string
+  isSelected: boolean
+  onPress: (option: string) => void
+}
+
+const AnimatedText = Animated.createAnimatedComponent(Text)
+
+const TabMenuItem = ({ isSelected, option, onPress }: TabMenuItemProps) => {
+  const codex = useSelector(selectThemeName)
+  const selectedColor = themeColors[codex].primary[50]
+  const inactiveColor = themeColors[codex].primary[300]
+
+  const color = useSharedValue(isSelected ? 1 : 0)
+  useEffect(() => {
+    if (isSelected) {
+      color.value = withTiming(1, { duration: 200 })
+    } else {
+      color.value = withTiming(0, { duration: 200 })
+    }
+  })
+
+  const rStyle = useAnimatedStyle(() => ({
+    color: interpolateColor(color.value, [0, 1], [inactiveColor, selectedColor])
+  }))
+
+  return (
+    <Pressable
+      className='flex-1 items-center justify-center rounded-2xl px-4 py-2 shadow-soft-1'
+      onPress={() => {
+        onPress(option)
+      }}
+    >
+      <AnimatedText
+        className='text-sm uppercase'
+        family='body-bold'
+        style={rStyle}
+      >
+        {option}
+      </AnimatedText>
+    </Pressable>
+  )
+}
+
+export default TabMenuItem

--- a/components/TabMenu/index.ts
+++ b/components/TabMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TabMenu'

--- a/components/Text/Text.tsx
+++ b/components/Text/Text.tsx
@@ -1,5 +1,11 @@
-import { type ComponentProps } from 'react'
+import {
+  type ForwardRefRenderFunction,
+  type ComponentProps,
+  forwardRef,
+  memo
+} from 'react'
 import { GSText } from '../ui'
+import { type Text as RNTextType } from 'react-native'
 
 type TextProps = ComponentProps<typeof GSText> & {
   family?:
@@ -12,10 +18,14 @@ type TextProps = ComponentProps<typeof GSText> & {
     | 'heading-regular'
 }
 
-const Text = ({ family = 'body-regular', ...props }: TextProps) => (
+const Text: ForwardRefRenderFunction<RNTextType, TextProps> = (
+  { family = 'body-regular', ...props },
+  ref
+) => (
   <GSText
     {...props}
     style={{ fontFamily: fontFamilyMap[family] }}
+    ref={ref}
   />
 )
 
@@ -29,4 +39,4 @@ const fontFamilyMap: Record<NonNullable<TextProps['family']>, string> = {
   'heading-regular': 'Silkscreen_400Regular'
 }
 
-export default Text
+export default memo(forwardRef(Text))

--- a/components/index.ts
+++ b/components/index.ts
@@ -10,6 +10,7 @@ export { default as Progress } from './Progress'
 export { default as Text } from './Text'
 export { default as UnitSelector } from './UnitSelector'
 export { default as TabMenu } from './TabMenu'
+export { default as InsetShadow } from './InsetShadow'
 
 export * from './store'
 export * from './ui'

--- a/components/index.ts
+++ b/components/index.ts
@@ -9,6 +9,7 @@ export { default as NavigationHeader } from './NavigationHeader'
 export { default as Progress } from './Progress'
 export { default as Text } from './Text'
 export { default as UnitSelector } from './UnitSelector'
+export { default as TabMenu } from './TabMenu'
 
 export * from './store'
 export * from './ui'

--- a/components/ui/gluestack-ui-provider/colors.ts
+++ b/components/ui/gluestack-ui-provider/colors.ts
@@ -3,7 +3,7 @@ import { type ThemeName } from 'appdeptus/components/store'
 type ColorVariant = 'primary' | 'secondary' | 'tertiary'
 type Shade = 50 | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 950
 
-const colors: Record<ThemeName, Record<ColorVariant, Record<Shade, string>>> = {
+const colors = {
   default: {
     primary: {
       50: '#f5f7fa',
@@ -1030,7 +1030,10 @@ const colors: Record<ThemeName, Record<ColorVariant, Record<Shade, string>>> = {
       950: '#10231e'
     }
   }
-}
+} as const satisfies Record<
+  ThemeName,
+  Record<ColorVariant, Record<Shade, string>>
+>
 
 export default colors
 export type { ColorVariant, Shade }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "expo-app",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo-google-fonts/ibm-plex-mono": "^0.2.3",
         "@expo-google-fonts/silkscreen": "^0.2.3",
@@ -19,6 +20,7 @@
         "@gluestack-ui/toast": "^1.0.7",
         "@react-native-async-storage/async-storage": "1.23.1",
         "@reduxjs/toolkit": "^2.1.0",
+        "@shopify/react-native-skia": "1.2.3",
         "@supabase/supabase-js": "^2.39.3",
         "ahooks": "^3.7.10",
         "babel-plugin-inline-import": "^3.0.0",
@@ -8090,6 +8092,31 @@
         "join-component": "^1.1.0"
       }
     },
+    "node_modules/@shopify/react-native-skia": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-1.2.3.tgz",
+      "integrity": "sha512-gyUD/HGsMyZ+YAoWxVh24HYN5juwC/dZWINL/0sKP7Ttee/0igCRxWPneH1BbVH28dhyf+tvksQNUwpMM3VWbg==",
+      "dependencies": {
+        "canvaskit-wasm": "0.39.1",
+        "react-reconciler": "0.27.0"
+      },
+      "bin": {
+        "setup-skia-web": "scripts/setup-canvaskit.js"
+      },
+      "peerDependencies": {
+        "react": ">=18.0",
+        "react-native": ">=0.64",
+        "react-native-reanimated": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -9611,6 +9638,11 @@
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
       "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw=="
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow=="
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
@@ -10915,6 +10947,14 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.39.1.tgz",
+      "integrity": "sha512-Gy3lCmhUdKq+8bvDrs9t8+qf7RvcjuQn+we7vTVVyqgOVO1UVfHpsnBxkTZw+R4ApEJ3D5fKySl9TU11hmjl/A==",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -19643,6 +19683,29 @@
       "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
       "dependencies": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/react-redux": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "DARK_MODE=media expo run:android",
     "ios": "DARK_MODE=media expo run:ios",
     "web": "DARK_MODE=media expo start --web",
-    "storybook-generate": "sb-rn-get-stories"
+    "storybook-generate": "sb-rn-get-stories",
+    "postinstall": "npx setup-skia-web"
   },
   "dependencies": {
     "@expo-google-fonts/ibm-plex-mono": "^0.2.3",
@@ -59,7 +60,8 @@
     "react-native-web": "~0.19.6",
     "react-redux": "^9.1.0",
     "tailwindcss": "^3.4.13",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@shopify/react-native-skia": "1.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",


### PR DESCRIPTION
### Description
This pr adds the following components:
- tab menu, used as a top navigation bar with press capabilities
- inset shadow, used to render a shadow that mimics the `box-shadow: inset` prop on the web.

### Additional changes
Text component is now a `forwardRef`, since it was needed to be able to pass it to `createAnimatedComponent`. The new web assembly file is there in order to make the app web compatible, but the actual loading of react native skia on the web has not been done yet, I'd keep it for when it's actually needed

### Comments
`@shopify/react-native-skia` has been installed since inset shadows are not possible on standard components due to how drop-shadows are rendered on the native side. The solution provided is efficient since it relies on rounded rectangles, see [here](https://shopify.github.io/react-native-skia/docs/shapes/box/#example) and [here](https://github.com/Shopify/react-native-skia/issues/252) for more info