### PR TITLE
feat: double check screen 📋

### DIFF
--- a/app/games/new/_layout.tsx
+++ b/app/games/new/_layout.tsx
@@ -48,6 +48,9 @@ const NewGameLayout = () => {
       case 'embarked-selection':
         return 4
 
+      case 'double-check':
+        return 5
+
       default:
         return 0
     }
@@ -63,6 +66,9 @@ const NewGameLayout = () => {
 
       case 'embarked-selection':
         return 'select units to embark'
+
+      case 'double-check':
+        return 'Awaiting the call to war'
 
       default:
         return ''
@@ -87,6 +93,13 @@ const NewGameLayout = () => {
         }
 
       case 'embarked-selection':
+        return {
+          icon: ChevronRight,
+          href: 'games/new/double-check',
+          variant: 'link'
+        }
+
+      case 'double-check':
         return {
           icon: QrCode,
           loading: isLoading,
@@ -123,7 +136,7 @@ const NewGameLayout = () => {
           variant='backButton'
           progress={{
             currentStep,
-            steps: 4,
+            steps: 5,
             text
           }}
           rightButton={rightButton}

--- a/app/games/new/double-check.tsx
+++ b/app/games/new/double-check.tsx
@@ -1,0 +1,5 @@
+import { DoubleCheckScreen } from 'appdeptus/modules/games/screens'
+
+const DoubleCheckRoute = () => <DoubleCheckScreen />
+
+export default DoubleCheckRoute

--- a/modules/games/screens/ArmySelection/ArmySelection.tsx
+++ b/modules/games/screens/ArmySelection/ArmySelection.tsx
@@ -30,21 +30,18 @@ const NewGameScreen = () => {
     >
       <ScreenTitle>new game</ScreenTitle>
       <ScreenSubtitle>choose your warhost</ScreenSubtitle>
+      <Text
+        family='body-regular-italic'
+        size='sm'
+      >
+        Commander, select your chosen army from the ranks of your forces and
+        follow the prescribed rites of preparation! Only through readiness shall
+        victory be forged in the crucible of war.
+      </Text>
 
       <FlatList
         data={data}
         keyExtractor={({ id }) => String(id)}
-        ListHeaderComponent={
-          <Text
-            className='py-4'
-            family='body-regular-italic'
-          >
-            Assemble your forces, warrior of the Imperium. When your army stands
-            ready, tap the QR Seal of the Omnissiah in the top right. This
-            sacred glyph shall encode your war protocols. Let your opponent scan
-            it, and the rites of battle shall commence.
-          </Text>
-        }
         ItemSeparatorComponent={() => <VStack className='h-4' />}
         ListFooterComponent={() => <VStack className='h-4' />}
         renderItem={({ item }) => (

--- a/modules/games/screens/DoubleCheck/DoubleCheck.tsx
+++ b/modules/games/screens/DoubleCheck/DoubleCheck.tsx
@@ -1,0 +1,44 @@
+import {
+  ArmyRoster,
+  ScreenContainer,
+  ScreenTitle,
+  Text,
+  VStack
+} from 'appdeptus/components'
+import { type NewGame } from 'appdeptus/models/game'
+import { useFormContext } from 'react-hook-form'
+
+const DoubleCheckScreen = () => {
+  const { watch } = useFormContext<NewGame>()
+
+  const codex = watch('playerOne.army.codex.name')
+
+  const roster = watch('playerOne.army.roster')
+
+  return (
+    <ScreenContainer
+      className='bg-primary-950 p-4'
+      space='md'
+    >
+      <ScreenTitle>{codex}</ScreenTitle>
+      <Text
+        family='body-regular-italic'
+        size='sm'
+      >
+        Your forces are assembled and your army stands ready, warrior! Tap the
+        QR Seal of the Omnissiah in the top right. This sacred glyph shall
+        encode your war protocols. Let your opponent scan it, and the rites of
+        battle shall commence.
+      </Text>
+
+      <VStack
+        className='flex-1'
+        space='md'
+      >
+        <ArmyRoster roster={roster} />
+      </VStack>
+    </ScreenContainer>
+  )
+}
+
+export default DoubleCheckScreen

--- a/modules/games/screens/DoubleCheck/index.ts
+++ b/modules/games/screens/DoubleCheck/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DoubleCheck'

--- a/modules/games/screens/index.ts
+++ b/modules/games/screens/index.ts
@@ -1,4 +1,5 @@
 export { default as ArmySelectionScreen } from './ArmySelection'
+export { default as DoubleCheckScreen } from './DoubleCheck'
 export { default as EmbarkedSelectionScreen } from './EmbarkedSelection'
 export { default as GameScreen } from './Game'
 export { default as JoinGameScreen } from './Join'


### PR DESCRIPTION
This pull request introduces the **Double Check Screen**, which serves as the final step in the New Game flow. This screen is designed to ensure that users can review and confirm their game settings before starting a new game, enhancing usability and reducing potential setup errors.

## Features Implemented
- **Double Check Screen**:
  - Displays a summary of the selected game settings.
  - Allows users to confirm or go back to modify their selections.
