### PR TITLE
feat: edit user name ✏

### DIFF
--- a/app/(home)/user/_layout.tsx
+++ b/app/(home)/user/_layout.tsx
@@ -7,6 +7,7 @@ const UserLayout = () => (
     screenOptions={defaultScreenOptions}
   >
     <Stack.Screen name='index' />
+    <Stack.Screen name='edit-name' />
     <Stack.Screen
       name='privacy-policy'
       options={{

--- a/app/(home)/user/edit-name.tsx
+++ b/app/(home)/user/edit-name.tsx
@@ -1,0 +1,5 @@
+import { EditNameScreen } from 'appdeptus/modules/user/Screens'
+
+const EditNameRoute = () => <EditNameScreen />
+
+export default EditNameRoute

--- a/modules/root/api/endpoints/signInWithApple.ts
+++ b/modules/root/api/endpoints/signInWithApple.ts
@@ -1,11 +1,12 @@
-import { type AuthTokenResponsePassword } from '@supabase/supabase-js'
 import { type SessionEndpointBuilder } from 'appdeptus/api'
 import { supabase } from 'appdeptus/utils'
 import * as AppleAuthentication from 'expo-apple-authentication'
 import SessionApiTag from '../tags'
+import { type SignInResponse } from '../types'
+import { isNewUser } from '../utils'
 
 const signInWithApple = (builder: SessionEndpointBuilder<SessionApiTag>) =>
-  builder.mutation<AuthTokenResponsePassword['data'], void>({
+  builder.mutation<SignInResponse, void>({
     queryFn: async () => {
       try {
         const credential = await AppleAuthentication.signInAsync({
@@ -29,7 +30,7 @@ const signInWithApple = (builder: SessionEndpointBuilder<SessionApiTag>) =>
             return { error: 'no ID token present' }
           }
 
-          return { data }
+          return { data: { ...data, isNew: isNewUser(data.user) } }
         }
 
         return { error: 'no ID token present' }

--- a/modules/root/api/endpoints/signInWithGoogle.ts
+++ b/modules/root/api/endpoints/signInWithGoogle.ts
@@ -1,11 +1,20 @@
 import { GoogleSignin } from '@react-native-google-signin/google-signin'
-import { type AuthTokenResponsePassword } from '@supabase/supabase-js'
 import { type SessionEndpointBuilder } from 'appdeptus/api'
 import { supabase } from 'appdeptus/utils'
 import SessionApiTag from '../tags'
+import { type SignInResponse } from '../types'
+import { isNewUser } from '../utils'
+
+GoogleSignin.configure({
+  scopes: ['email', 'profile'],
+  webClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID,
+  iosClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS,
+  forceCodeForRefreshToken: true,
+  offlineAccess: true
+})
 
 const signInWithGoogle = (builder: SessionEndpointBuilder<SessionApiTag>) =>
-  builder.mutation<AuthTokenResponsePassword['data'], void>({
+  builder.mutation<SignInResponse, void>({
     queryFn: async () => {
       try {
         await GoogleSignin.hasPlayServices()
@@ -20,7 +29,7 @@ const signInWithGoogle = (builder: SessionEndpointBuilder<SessionApiTag>) =>
 
           if (supabaseData.session && supabaseData.user) {
             return {
-              data: supabaseData
+              data: { ...supabaseData, isNew: isNewUser(supabaseData.user) }
             }
           }
 

--- a/modules/root/api/types.ts
+++ b/modules/root/api/types.ts
@@ -1,8 +1,16 @@
+import { type Session, type User } from '@supabase/supabase-js'
+
 type Provider = 'azure'
 
 const isProvider = (provider: string): provider is Provider =>
   provider === 'azure'
 
+type SignInResponse = {
+  user: User
+  session: Session
+  isNew: boolean
+}
+
 export { isProvider }
 
-export type { Provider }
+export type { Provider, SignInResponse }

--- a/modules/root/api/utils.ts
+++ b/modules/root/api/utils.ts
@@ -1,0 +1,10 @@
+import { type User } from '@supabase/supabase-js'
+
+const isNewUser = (user: User) => {
+  const createdAt = new Date(user.created_at)
+  const lastSignInAt = new Date(user.last_sign_in_at ?? Date.now())
+
+  return Math.abs(createdAt.getTime() - lastSignInAt.getTime()) < 1000
+}
+
+export { isNewUser }

--- a/modules/root/screens/Root/SignInWithApple.tsx
+++ b/modules/root/screens/Root/SignInWithApple.tsx
@@ -25,6 +25,11 @@ const SignInWithApple = () => {
           return
         }
 
+        if (res.data.isNew) {
+          router.replace('user/edit-name')
+          return
+        }
+
         router.replace('/')
       }}
       disabled={isLoading}

--- a/modules/root/screens/Root/SignInWithGoogle.tsx
+++ b/modules/root/screens/Root/SignInWithGoogle.tsx
@@ -1,18 +1,9 @@
-import { GoogleSignin } from '@react-native-google-signin/google-signin'
 import googleIcon from 'appdeptus/assets/svg/google.svg'
 import { Card, HStack, Pressable, Text, useToast } from 'appdeptus/components'
 import { router } from 'expo-router'
 import { memo } from 'react'
 import { SvgXml } from 'react-native-svg'
 import { useSignInWithGoogleMutation } from '../../api'
-
-GoogleSignin.configure({
-  scopes: ['email', 'profile'],
-  webClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID,
-  iosClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS,
-  forceCodeForRefreshToken: true,
-  offlineAccess: true
-})
 
 const SignInWithGoogle = () => {
   const [signInWithGoogle, { isLoading }] = useSignInWithGoogleMutation()
@@ -26,6 +17,11 @@ const SignInWithGoogle = () => {
 
         if ('error' in res) {
           show({ title: '⚠️ error', description: String(res.error) })
+          return
+        }
+
+        if (res.data.isNew) {
+          router.replace('user/edit-name')
           return
         }
 

--- a/modules/root/screens/Root/SignInWithMicrosoft.tsx
+++ b/modules/root/screens/Root/SignInWithMicrosoft.tsx
@@ -20,6 +20,11 @@ const SignInWithMicrosoft = () => {
           return
         }
 
+        if (res.data.isNew) {
+          router.replace('user/edit-name')
+          return
+        }
+
         router.replace('/')
       }}
       disabled={isLoading}

--- a/modules/user/Screens/EditName/EditName.tsx
+++ b/modules/user/Screens/EditName/EditName.tsx
@@ -1,0 +1,52 @@
+import {
+  Error,
+  Loading,
+  NavigationHeader,
+  ScreenContainer,
+  VStack
+} from 'appdeptus/components'
+import { RefreshCcw } from 'lucide-react-native'
+import { useGetUserProfileQuery } from '../../api'
+import Form from './Form'
+
+const EditNameScreen = () => {
+  const { data, isError, isFetching, refetch } = useGetUserProfileQuery()
+
+  if (isError) {
+    return (
+      <ScreenContainer className='p-4'>
+        <NavigationHeader
+          variant='backButton'
+          rightButton={{
+            variant: 'callback',
+            onPress: refetch,
+            icon: RefreshCcw,
+            loading: isFetching
+          }}
+        />
+        <VStack className='items-center justify-center'>
+          <Error />
+        </VStack>
+      </ScreenContainer>
+    )
+  }
+
+  if (!data) {
+    return (
+      <ScreenContainer className='items-center justify-center'>
+        <Loading />
+      </ScreenContainer>
+    )
+  }
+
+  return (
+    <ScreenContainer
+      className='p-4'
+      safeAreaInsets={['top', 'bottom']}
+    >
+      <Form name={data.name} />
+    </ScreenContainer>
+  )
+}
+
+export default EditNameScreen

--- a/modules/user/Screens/EditName/Form.tsx
+++ b/modules/user/Screens/EditName/Form.tsx
@@ -1,0 +1,102 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  Input,
+  NavigationHeader,
+  ScreenSubtitle,
+  ScreenTitle,
+  Text,
+  useToast,
+  VStack
+} from 'appdeptus/components'
+import { router } from 'expo-router'
+import { Save, User } from 'lucide-react-native'
+import { useCallback } from 'react'
+import {
+  Controller,
+  FormProvider,
+  type SubmitHandler,
+  useForm
+} from 'react-hook-form'
+import { z } from 'zod'
+import { useUpdateUserNameMutation } from '../../api'
+
+type FormProps = {
+  name: string
+}
+
+const Form = ({ name }: FormProps) => {
+  const form = useForm<{ name: string }>({
+    defaultValues: { name },
+    mode: 'onChange',
+    resolver: zodResolver(
+      z.object({
+        name: z.string().min(1, { message: 'Nickname cannot be empty' })
+      })
+    )
+  })
+
+  const [updateUserName] = useUpdateUserNameMutation()
+
+  const { show } = useToast()
+
+  const handleUpdateUserName = useCallback<SubmitHandler<{ name: string }>>(
+    async ({ name }) => {
+      const res = await updateUserName(name)
+
+      if ('error' in res) {
+        show({ description: String(res.error), title: '⚠️ error' })
+        return
+      }
+
+      if (router.canGoBack()) {
+        router.back()
+        return
+      }
+
+      router.replace('/')
+    },
+    [show, updateUserName]
+  )
+
+  return (
+    <VStack space='md'>
+      <NavigationHeader
+        variant='backButton'
+        rightButton={{
+          variant: 'callback',
+          onPress: form.handleSubmit(handleUpdateUserName),
+          icon: Save,
+          loading: form.formState.isSubmitting,
+          disabled: !form.formState.isValid && !form.formState.isDirty
+        }}
+      />
+      <ScreenTitle>edit nickname</ScreenTitle>
+      <ScreenSubtitle>choose your battle name</ScreenSubtitle>
+      <FormProvider {...form}>
+        <Controller
+          name='name'
+          control={form.control}
+          disabled={form.formState.isSubmitting}
+          render={({ field, fieldState }) => (
+            <VStack space='md'>
+              <Input
+                Icon={User}
+                onChangeText={field.onChange}
+                placeholder='The name displayed on your dog tag'
+                {...field}
+                onSubmitEditing={form.handleSubmit(handleUpdateUserName)}
+              />
+              {fieldState.error ? (
+                <Text className='text-tertiary-700'>
+                  {fieldState.error.message}
+                </Text>
+              ) : null}
+            </VStack>
+          )}
+        />
+      </FormProvider>
+    </VStack>
+  )
+}
+
+export default Form

--- a/modules/user/Screens/EditName/index.ts
+++ b/modules/user/Screens/EditName/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EditName'

--- a/modules/user/Screens/User/User.tsx
+++ b/modules/user/Screens/User/User.tsx
@@ -3,6 +3,7 @@ import {
   Avatar,
   Card,
   HStack,
+  Loading,
   NavigationHeader,
   ScreenContainer,
   Text,
@@ -12,6 +13,7 @@ import {
 import { useSignOutMutation } from 'appdeptus/modules/root/api'
 import { formatDate } from 'date-fns'
 import * as Application from 'expo-application'
+import { Link } from 'expo-router'
 import { Bot, Code, LogOut } from 'lucide-react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { SvgXml } from 'react-native-svg'
@@ -26,7 +28,7 @@ const UserScreen = () => {
   if (!data) {
     return (
       <ScreenContainer className='items-center justify-center'>
-        {data}
+        <Loading />
       </ScreenContainer>
     )
   }
@@ -64,12 +66,17 @@ const UserScreen = () => {
               className='items-center justify-center'
               space='xs'
             >
-              <Text
-                family='heading-regular'
-                size='2xl'
+              <Link
+                href='./edit-name'
+                relativeToDirectory
               >
-                {data.name}
-              </Text>
+                <Text
+                  family='heading-regular'
+                  size='2xl'
+                >
+                  {data.name}
+                </Text>
+              </Link>
               <Text
                 className='text-primary-400'
                 family='body-bold'

--- a/modules/user/Screens/index.ts
+++ b/modules/user/Screens/index.ts
@@ -1,1 +1,2 @@
+export { default as EditNameScreen } from './EditName'
 export { default as UserScreen } from './User'

--- a/modules/user/api/api.ts
+++ b/modules/user/api/api.ts
@@ -1,11 +1,15 @@
 import { coreApi } from 'appdeptus/api'
-import { getUserProfile } from './endpoints'
+import { getUserProfile, updateUserName } from './endpoints'
+import UserApiTag from './tags'
 
-const userApi = coreApi.injectEndpoints({
-  endpoints: (builder) => ({
-    getUserProfile: getUserProfile(builder)
-  }),
-  overrideExisting: true
-})
+const userApi = coreApi
+  .enhanceEndpoints({ addTagTypes: [UserApiTag.USER] })
+  .injectEndpoints({
+    endpoints: (builder) => ({
+      getUserProfile: getUserProfile(builder),
+      updateUserName: updateUserName(builder)
+    }),
+    overrideExisting: true
+  })
 
 export default userApi

--- a/modules/user/api/endpoints/index.ts
+++ b/modules/user/api/endpoints/index.ts
@@ -1,1 +1,2 @@
 export { default as getUserProfile } from './getUserProfile'
+export { default as updateUserName } from './updateUserName'

--- a/modules/user/api/hooks.ts
+++ b/modules/user/api/hooks.ts
@@ -1,5 +1,5 @@
 import userApi from './api'
 
-const { useGetUserProfileQuery } = userApi
+const { useGetUserProfileQuery, useUpdateUserNameMutation } = userApi
 
-export { useGetUserProfileQuery }
+export { useGetUserProfileQuery, useUpdateUserNameMutation }

--- a/modules/user/api/tags.ts
+++ b/modules/user/api/tags.ts
@@ -1,0 +1,5 @@
+enum UserApiTag {
+  USER = 'user'
+}
+
+export default UserApiTag


### PR DESCRIPTION
This PR introduces a new screen that allows users to set or edit their username. The screen is used in two scenarios:  
1. **New User Registration**: Presented to users immediately after completing registration to set their initial username.  
2. **Username Editing**: Accessible to existing users to modify their username at any time.
